### PR TITLE
EnvVars are now a JSON instead of []string

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,7 +99,7 @@ func TestJSONHandler(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedJSONOutput: toJSON(t, EnvVar{
 				Env:         "TYK_DATA_OBJECT1",
-				Value:       strconv.Itoa(complexStruct.Data.Object1),
+				Value:       complexStruct.Data.Object1,
 				ConfigField: "data.object_1",
 			}),
 		},
@@ -161,7 +160,7 @@ func TestEnvsHandler(t *testing.T) {
 				"field_value",
 			},
 			expectedStatusCode: http.StatusOK,
-			expectedJSONOutput: fmt.Sprintln(`["FIELDNAME:field_value"]`),
+			expectedJSONOutput: fmt.Sprintln(`{"FIELDNAME":"field_value"}`),
 		},
 		{
 			testName: "simple struct with prefix",
@@ -172,18 +171,18 @@ func TestEnvsHandler(t *testing.T) {
 			},
 			givenPrefix:        "TEST_",
 			expectedStatusCode: http.StatusOK,
-			expectedJSONOutput: fmt.Sprintln(`["TEST_FIELDNAME:field_value"]`),
+			expectedJSONOutput: fmt.Sprintln(`{"TEST_FIELDNAME":"field_value"}`),
 		},
 		{
 			testName:           "complex struct struct",
 			givenConfig:        complexStruct,
 			expectedStatusCode: http.StatusOK,
 			expectedJSONOutput: fmt.Sprintln(
-				`["NAME:name_value",` +
-					`"DATA_OBJECT1:1",` +
-					`"DATA_OBJECT2:true",` +
-					`"METADATA:map[key_99:{99 key99}]",` +
-					`"OMITTEDVALUE:"]`,
+				`{"NAME":"name_value",` +
+					`"DATA_OBJECT1":1,` +
+					`"DATA_OBJECT2":true,` +
+					`"METADATA":{"key_99":{"id":99, "value":"key99"}},` +
+					`"OMITTEDVALUE":""}`,
 			),
 		},
 		{
@@ -206,7 +205,7 @@ func TestEnvsHandler(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedJSONOutput: toJSON(t, EnvVar{
 				Env:         "TYK_DATA_OBJECT1",
-				Value:       strconv.Itoa(complexStruct.Data.Object1),
+				Value:       complexStruct.Data.Object1,
 				ConfigField: "data.object_1",
 			}),
 		},

--- a/parser.go
+++ b/parser.go
@@ -11,17 +11,16 @@ import (
 )
 
 // ParseEnvs parse Viewer config field, generating a string slice of prefix+key:value of each config field
-func (v *Viewer) ParseEnvs() []string {
-	var envs []string
+func (v *Viewer) ParseEnvs() map[string]interface{} {
+	envs := make(map[string]interface{})
 	envVars := v.envs
 
 	if len(envVars) == 0 {
 		envVars = parseEnvs(v.config, v.prefix)
 	}
 
-	for i := range envVars {
-		env := envVars[i]
-		envs = append(envs, v.prefix+env.String())
+	for _, value := range envVars {
+		envs[v.prefix+value.key] = value.Value
 	}
 
 	return envs
@@ -158,13 +157,13 @@ type EnvVar struct {
 	// Description represents the comment of the given struct fields.
 	Description string `json:"description,omitempty"`
 	// Value represents the value of the given struct fields.
-	Value string `json:"value"`
+	Value interface{} `json:"value"`
 }
 
 // String returns a key:value string from EnvVar
-func (ev EnvVar) String() string {
-	return ev.key + ":" + ev.Value
-}
+// func (ev EnvVar) String() string {
+// 	return ev.key + ":" + ev.Value
+// }
 
 func (ev *EnvVar) setKey(field *structs.Field) {
 	key := field.Name()
@@ -188,5 +187,5 @@ func (ev *EnvVar) setValue(field *structs.Field) {
 		return
 	}
 
-	ev.Value = fmt.Sprint(field.Value())
+	ev.Value = field.Value()
 }

--- a/parser.go
+++ b/parser.go
@@ -161,9 +161,9 @@ type EnvVar struct {
 }
 
 // String returns a key:value string from EnvVar
-// func (ev EnvVar) String() string {
-// 	return ev.key + ":" + ev.Value
-// }
+func (ev EnvVar) String() string {
+	return ev.key + ":" + fmt.Sprintf("%s", ev.Value)
+}
 
 func (ev *EnvVar) setKey(field *structs.Field) {
 	key := field.Name()

--- a/parser.go
+++ b/parser.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fatih/structs"
 )
 
-// ParseEnvs parse Viewer config field, generating a string slice of prefix+key:value of each config field
+// ParseEnvs parse Viewer config field, generating a map[string]interface{} of prefix+key:value of each config field
 func (v *Viewer) ParseEnvs() map[string]interface{} {
 	envs := make(map[string]interface{})
 	envVars := v.envs

--- a/parser_test.go
+++ b/parser_test.go
@@ -73,7 +73,7 @@ func TestParseEnvsValues(t *testing.T) {
 		testName     string
 		testStruct   interface{}
 		expectedLen  int
-		expectedEnvs []string
+		expectedEnvs map[string]interface{}
 	}{
 		{
 			testName: "KEY:VALUE common struct",
@@ -83,7 +83,7 @@ func TestParseEnvsValues(t *testing.T) {
 				Key: "Value",
 			},
 			expectedLen:  1,
-			expectedEnvs: []string{"KEY:Value"},
+			expectedEnvs: map[string]interface{}{"KEY": "Value"},
 		},
 		{
 			testName: "KEY:VALUE with json tag",
@@ -93,7 +93,7 @@ func TestParseEnvsValues(t *testing.T) {
 				Key: "Value",
 			},
 			expectedLen:  1,
-			expectedEnvs: []string{"JSONNAME:Value"},
+			expectedEnvs: map[string]interface{}{"JSONNAME": "Value"},
 		},
 		{
 			testName: "KEY:VALUE with json tag and omitempty",
@@ -103,7 +103,7 @@ func TestParseEnvsValues(t *testing.T) {
 				Key: "Value",
 			},
 			expectedLen:  1,
-			expectedEnvs: []string{"JSONNAME:Value"},
+			expectedEnvs: map[string]interface{}{"JSONNAME": "Value"},
 		},
 		{
 			testName: "KEY:VALUE with json '-' tag",
@@ -113,7 +113,7 @@ func TestParseEnvsValues(t *testing.T) {
 				Key: "Value",
 			},
 			expectedLen:  1,
-			expectedEnvs: []string{"KEY:Value"},
+			expectedEnvs: map[string]interface{}{"KEY": "Value"},
 		},
 	}
 
@@ -176,7 +176,7 @@ func TestParseEnvsPrefix(t *testing.T) {
 
 	envs := helper.ParseEnvs()
 
-	for _, env := range envs {
+	for env := range envs {
 		assert.True(t, strings.HasPrefix(env, prefix))
 	}
 }


### PR DESCRIPTION
Now when users hit `/envs` endpoint, they'll get a JSON instead of an array of strings. Also, we're not getting the actual data type of the values. Before, they were all parsed as strings.
Before:
```
[
    "APP_LISTENPORT:8080",
    "APP_DEBUG:true",
    "APP_LOGFILE:/var/log/app.log"
]
```

Now:
```
{
    "APP_DEBUG": true,
    "APP_LISTENPORT": 8080,
    "APP_LOGFILE": "/var/log/app.log"
}
```