### PR TITLE
Returning 404 when field not found

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
 

--- a/exporter.go
+++ b/exporter.go
@@ -20,13 +20,33 @@ func (v *Viewer) ConfigHandler(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	rw.Header().Set("Content-type", "application/json")
-	rw.WriteHeader(http.StatusOK)
+
+	if configField := r.URL.Query().Get(JSONQueryKey); configField != "" {
+		response := v.EnvNotation(configField)
+		if response.Value == nil {
+			rw.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(rw).Encode(map[string]string{
+				"error": "field not found",
+			})
+			return
+		}
+
+		err := json.NewEncoder(rw).Encode(response)
+		if err != nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		return
+	}
 
 	err := json.NewEncoder(rw).Encode(v.config)
 	if err != nil {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
+	rw.WriteHeader(http.StatusOK)
 }
 
 // DetailedConfigHandler exposes the detailed configuration struct as JSON fields
@@ -37,15 +57,25 @@ func (v *Viewer) DetailedConfigHandler(rw http.ResponseWriter, r *http.Request) 
 	}
 
 	rw.Header().Set("Content-type", "application/json")
-	rw.WriteHeader(http.StatusOK)
 
 	if configField := r.URL.Query().Get(JSONQueryKey); configField != "" {
-		err := json.NewEncoder(rw).Encode(v.EnvNotation(configField))
+		response := v.EnvNotation(configField)
+		if response.Value == nil {
+			rw.WriteHeader(http.StatusNotFound)
+			err := json.NewEncoder(rw).Encode(map[string]string{
+				"error": "field not found",
+			})
+			if err != nil {
+				return
+			}
+			return
+		}
+
+		err := json.NewEncoder(rw).Encode(response)
 		if err != nil {
 			rw.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-
 		return
 	}
 
@@ -64,15 +94,25 @@ func (v *Viewer) EnvsHandler(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	rw.Header().Set("Content-type", "application/json")
-	rw.WriteHeader(http.StatusOK)
 
 	if env := r.URL.Query().Get(EnvQueryKey); env != "" {
-		err := json.NewEncoder(rw).Encode(v.JSONNotation(env))
+		response := v.JSONNotation(env)
+		if response.Value == nil {
+			rw.WriteHeader(http.StatusNotFound)
+			err := json.NewEncoder(rw).Encode(map[string]string{
+				"error": "environment variable not found",
+			})
+			if err != nil {
+				return
+			}
+			return
+		}
+
+		err := json.NewEncoder(rw).Encode(response)
 		if err != nil {
 			rw.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-
 		return
 	}
 

--- a/exporter.go
+++ b/exporter.go
@@ -45,8 +45,6 @@ func (v *Viewer) ConfigHandler(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-
-	rw.WriteHeader(http.StatusOK)
 }
 
 // DetailedConfigHandler exposes the detailed configuration struct as JSON fields

--- a/exporter.go
+++ b/exporter.go
@@ -25,9 +25,14 @@ func (v *Viewer) ConfigHandler(rw http.ResponseWriter, r *http.Request) {
 		response := v.EnvNotation(configField)
 		if response.Value == nil {
 			rw.WriteHeader(http.StatusNotFound)
-			_ = json.NewEncoder(rw).Encode(map[string]string{
+
+			err := json.NewEncoder(rw).Encode(map[string]string{
 				"error": "field not found",
 			})
+			if err != nil {
+				return
+			}
+
 			return
 		}
 
@@ -60,12 +65,14 @@ func (v *Viewer) DetailedConfigHandler(rw http.ResponseWriter, r *http.Request) 
 		response := v.EnvNotation(configField)
 		if response.Value == nil {
 			rw.WriteHeader(http.StatusNotFound)
+
 			err := json.NewEncoder(rw).Encode(map[string]string{
 				"error": "field not found",
 			})
 			if err != nil {
 				return
 			}
+
 			return
 		}
 
@@ -97,12 +104,14 @@ func (v *Viewer) EnvsHandler(rw http.ResponseWriter, r *http.Request) {
 		response := v.JSONNotation(env)
 		if response.Value == nil {
 			rw.WriteHeader(http.StatusNotFound)
+
 			err := json.NewEncoder(rw).Encode(map[string]string{
 				"error": "environment variable not found",
 			})
 			if err != nil {
 				return
 			}
+
 			return
 		}
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -74,6 +74,7 @@ func TestConfigHandler(t *testing.T) {
 		expectedJSONOutput string
 
 		shouldDeleteConfig bool
+		queryParamVal      string
 	}{
 		{
 			testName: "simple struct",
@@ -98,6 +99,15 @@ func TestConfigHandler(t *testing.T) {
 			expectedJSONOutput: "",
 			shouldDeleteConfig: true,
 		},
+		{
+			testName:           "invalid field",
+			givenConfig:        complexStruct,
+			expectedStatusCode: http.StatusNotFound,
+			expectedJSONOutput: toJSON(t, map[string]string{
+				"error": "field not found",
+			}),
+			queryParamVal: "invalid_field",
+		},
 	}
 
 	for _, tc := range tcs {
@@ -106,6 +116,8 @@ func TestConfigHandler(t *testing.T) {
 			// pass 'nil' as the third parameter.
 			req, err := http.NewRequest("GET", "/", nil)
 			assert.NoError(t, err)
+
+			setQueryParams(req, JSONQueryKey, tc.queryParamVal)
 
 			structViewerConfig := Config{Object: tc.givenConfig}
 			helper, err := New(&structViewerConfig, "TYK_")
@@ -196,8 +208,10 @@ func TestDetailedConfigHandler(t *testing.T) {
 			testName:           "invalid field complexStruct via query param",
 			givenConfig:        complexStruct,
 			queryParamVal:      "data.object_3",
-			expectedStatusCode: http.StatusOK,
-			expectedJSONOutput: toJSON(t, EnvVar{}),
+			expectedStatusCode: http.StatusNotFound,
+			expectedJSONOutput: toJSON(t, map[string]string{
+				"error": "field not found",
+			}),
 		},
 		{
 			testName: "not initialized",
@@ -321,8 +335,10 @@ func TestEnvsHandler(t *testing.T) {
 			givenConfig:        complexStruct,
 			givenPrefix:        "TYK_",
 			queryParamVal:      "TYK_DATA_OBJECT3",
-			expectedStatusCode: http.StatusOK,
-			expectedJSONOutput: toJSON(t, EnvVar{}),
+			expectedStatusCode: http.StatusNotFound,
+			expectedJSONOutput: toJSON(t, map[string]string{
+				"error": "environment variable not found",
+			}),
 		},
 	}
 


### PR DESCRIPTION
If a field is not found in the /config or /env handlers, we're returning an error and 404 status code.